### PR TITLE
fix: fix height for percentage based heights

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,7 +59,7 @@ const { title } = Astro.props
 
 			html,
 			body {
-				min-height: 100%;
+				height: 100%;
 			}
 		</style>
 


### PR DESCRIPTION
Apply correct height style on html & body so we can use percentage based heights on body children elements.

https://www.joshwcomeau.com/css/custom-css-reset/#digit-percentage-based-heights