### PR TITLE
fix: add size and loading lazy to images

### DIFF
--- a/src/components/Participants.astro
+++ b/src/components/Participants.astro
@@ -3,7 +3,7 @@ const { showAll = false } = Astro.props
 
 const MAX_ITEMS = 50
 
-async function getParticipants () {
+async function getParticipants() {
 	const items = await Astro.glob('../pages/entry/*/index.astro')
 
 	return items
@@ -28,6 +28,9 @@ const shownParticipants = showAll ? participants : participants.slice(0, MAX_ITE
 					href={'/entry/' + name}
 				>
 					<img
+						loading='lazy'
+						width='80px'
+						height='80px'
 						class='rounded-full w-full h-auto'
 						src={'https://unavatar.io/github/' + name}
 						alt={name}


### PR DESCRIPTION
Add a fixed size to the images to prevent a layout shift when images load and set the loading attribute to lazy.