### PR TITLE
fix(layout): update OG metatags attribute to `property`

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,14 +24,14 @@ const { title } = Astro.props
 		/>
 		<meta name='twitter:image' content='https://hacktoberfest-2022.vercel.app/image.jpg' />
 
-		<meta name='og:image' content='https://hacktoberfest-2022.vercel.app/image.jpg' />
-		<meta name='og:title' content='Hacktoberfest 2022' />
+		<meta property='og:image' content='https://hacktoberfest-2022.vercel.app/image.jpg' />
+		<meta property='og:title' content='Hacktoberfest 2022' />
 		<meta
-			name='og:description'
+			property='og:description'
 			content='Participa en el Hacktoberfest con la comunidad de midudev'
 		/>
-		<meta name='og:site_name' content='Midudev Hacktoberfest 2022' />
-		<meta name='og:type' content='website' />
+		<meta property='og:site_name' content='Midudev Hacktoberfest 2022' />
+		<meta property='og:type' content='website' />
 
 		<title>{title}</title>
 	</head>


### PR DESCRIPTION
# ⭐ Descripción

Updated main site layout open graph meta tags to use the property attribute instead of `name` as specified by [open graph protocol](https://ogp.me/#metadata)

## 🚀 Tipo de cambio

- [x] Arreglo de bug (cambios que no rompen nada y resuelven un problema).
- [ ] Nueva característica (cambios que no rompen nada y agregan funcionalidad).
- [x] Cambio radical (arreglo o característica que podría causar que una funcionalidad no funcione como se espera).
- [ ] Este cambio requiere actualización de documentación.

# 🤔 ¿Cómo ha sido probado este cambio?

- [x] Tested changes in opengraph.xyz and metatags.io